### PR TITLE
bump node-client dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   "dependencies": {
     "lodash.defaults": "^4.0.1",
     "lodash.omit": "^4.1.0",
-    "neovim-client": "^1.0.8"
+    "neovim-client": "^1.1.0"
   }
 }


### PR DESCRIPTION
Plugins are affected by https://github.com/neovim/node-client/issues/15 and need these changes too. 
