### PR TITLE
Add travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+
+before_install:
+  - eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
+  - nvim --version
+
+node_js:
+  - 'stable'
+  - 'lts/*'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # node-host
 
+[![Build Status](https://travis-ci.org/neovim/node-host.png)](https://travis-ci.org/neovim/node-host)
+<br>
+
 ## Installation
 
 **Prerequisites:** You must have the `node` executable on your PATH and a copy of `npm`


### PR DESCRIPTION
To better track upstream changes, it would be nice to have a travis-ci build running on this project (it's currently failing due to neovim api changes).

Changed the gulpfile slightly because the test was hanging:
https://github.com/sindresorhus/gulp-mocha/issues/54
